### PR TITLE
A better way to record new cassettes

### DIFF
--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -2,7 +2,11 @@ require 'vcr'
 require 'webmock/cucumber'
 
 VCR.configure do |c|
-  c.default_cassette_options = { :record => :once }
+  if ENV['VCR_RECORD'] == 'yes'
+    c.default_cassette_options = { :record => :once }
+  else
+    c.default_cassette_options = { :record => :none }
+  end
   c.cassette_library_dir = 'fixtures/cucumber/vcr'
   c.hook_into :webmock
   c.allow_http_connections_when_no_cassette = true

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -9,7 +9,7 @@ VCR.configure do |c|
   end
   c.cassette_library_dir = 'fixtures/cucumber/vcr'
   c.hook_into :webmock
-  c.allow_http_connections_when_no_cassette = true
+  c.allow_http_connections_when_no_cassette = false
 
   c.filter_sensitive_data('http://elastic.search/') { ENV['ES_URL'] }
   c.filter_sensitive_data('http://elastic.search/') { u = URI(ENV['ES_URL']); u.userinfo = ''; u.to_s }

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -10,6 +10,9 @@ VCR.configure do |c|
   c.cassette_library_dir = 'fixtures/cucumber/vcr'
   c.hook_into :webmock
   c.allow_http_connections_when_no_cassette = true
+
+  c.filter_sensitive_data('http://elastic.search/') { ENV['ES_URL'] }
+  c.filter_sensitive_data('http://elastic.search/') { u = URI(ENV['ES_URL']); u.userinfo = ''; u.to_s }
 end
 
 VCR.cucumber_tags do |t|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,9 @@ end
 
 ENV['RACK_ENV'] = 'test'
 # Comment out when recording new VCR cassettes
-ENV['ES_URL'] = 'http://elastic.search/'
+unless ENV['VCR_RECORD'] == 'yes'
+  ENV['ES_URL'] = 'http://elastic.search/'
+end
 
 require 'rack/test'
 require_relative 'support/vcr_setup'

--- a/spec/support/vcr_setup.rb
+++ b/spec/support/vcr_setup.rb
@@ -3,7 +3,11 @@ require 'vcr'
 VCR.configure do |c|
   c.cassette_library_dir = 'fixtures/rspec/vcr'
   c.hook_into :webmock
-  c.default_cassette_options = { :record => :once }
+  if ENV['VCR_RECORD'] == 'yes'
+    c.default_cassette_options = { :record => :once }
+  else
+    c.default_cassette_options = { :record => :none }
+  end
   c.allow_http_connections_when_no_cassette = true
 
   c.filter_sensitive_data('http://elastic.search/') { ENV['ES_URL'] }

--- a/spec/support/vcr_setup.rb
+++ b/spec/support/vcr_setup.rb
@@ -8,7 +8,7 @@ VCR.configure do |c|
   else
     c.default_cassette_options = { :record => :none }
   end
-  c.allow_http_connections_when_no_cassette = true
+  c.allow_http_connections_when_no_cassette = false
 
   c.filter_sensitive_data('http://elastic.search/') { ENV['ES_URL'] }
   c.filter_sensitive_data('http://elastic.search/') { u = URI(ENV['ES_URL']); u.userinfo = ''; u.to_s }


### PR DESCRIPTION
If you need to record new VCR cassettes, write a spec/feature and run
either:

```
VCR_RECORD=yes rspec
```

or:

```
VCR_RECORD=yes cucumber
```

Other tests will fail but it will record the result of the new requests.
You can then rerun the tests with either `rspec` or `cucumber`
