### PR TITLE
Remove border radius on levels

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -46,6 +46,7 @@ form {
   border-radius: 20px 20px 0 0;
   width: 100%;
   position: relative;
+  overflow: hidden;
 }
 
 .carriage .num {
@@ -60,7 +61,6 @@ form {
   position: absolute;
   bottom: 0;
   background-color: orange;
-  border-radius: 20px 20px 0 0;
 }
 
 .carriage .windows {


### PR DESCRIPTION
Turns out we can use `overflow: hidden` to hide the overflowing corners when the level gets too high
