### PR TITLE
Show next trains

### DIFF
--- a/config/stations.yml
+++ b/config/stations.yml
@@ -1,49 +1,65 @@
 walthamstow_central:
   southbound: 37
   northbound: 30
+  naptan: 940GZZLUWWL
 blackhorse_road:
   southbound: 123
   northbound: 128
+  naptan: 940GZZLUBLR
 tottenham_hale:
   southbound: 195
   northbound: 206
+  naptan: 940GZZLUTMH
 seven_sisters:
   southbound: 329
   northbound: 492
+  naptan: 940GZZLUSVS
 finsbury_park:
   southbound: 893
   northbound: 870
+  naptan: 940GZZLUFPK
 highbury_and_islington:
   southbound: 1035
   northbound: 1026
+  naptan: 940GZZLUHAI
 kings_cross_st_pancras:
   southbound: 1193
   northbound: 1174
+  naptan: 940GZZLUKSX
 euston:
   southbound: 1309
   northbound: 1286
+  naptan: 940GZZLUEUS
 warren_street:
   southbound: 1377
   northbound: 1362
+  naptan: 940GZZLUWRR
 oxford_circus:
   southbound: 1463
   northbound: 1430
+  naptan: 940GZZLUOXC
 green_park:
   southbound: 1525
   northbound: 1496
+  naptan: 940GZZLUGPK
 victoria:
   southbound: 1643
   northbound: 1614
+  naptan: 940GZZLUVIC
 pimlico:
   southbound: 1753
   northbound: 1746
   class: normal
+  naptan: 940GZZLUPCO
 vauxhall:
   southbound: 1809
   northbound: 1798
+  naptan: 940GZZLUVXL
 stockwell:
   southbound: 1901
   northbound: 1894
+  naptan: 940GZZLUSKW
 brixton:
   southbound: 2007
   northbound: 1992
+  naptan: 940GZZLUBXN

--- a/fixtures/rspec/vcr/SirHandel_App/sets_a_default_datetime_at_the_same_local_time.yml
+++ b/fixtures/rspec/vcr/SirHandel_App/sets_a_default_datetime_at_the_same_local_time.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.tfl.gov.uk/line/victoria/arrivals?direction=outbound&stopPointId=940GZZLUSVS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type
+      Access-Control-Allow-Methods:
+      - GET,POST,PUT,DELETE,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Age:
+      - '0'
+      Api-Entity-Payload:
+      - Prediction
+      Cache-Control:
+      - public, must-revalidate, max-age=25, s-maxage=50
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 19 Jan 2016 15:47:38 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Via:
+      - 1.1 varnish
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Backend:
+      - api
+      X-Backend-Url:
+      - "/line/victoria/arrivals?stopPointId=940GZZLUSVS&direction=outbound"
+      X-Banning:
+      - ''
+      X-Cache:
+      - MISS
+      X-Cacheable:
+      - Yes. Cacheable
+      X-Hash-Url:
+      - "/line/victoria/arrivals?direction=outbound&stoppointid=940gzzlusvs"
+      X-Ttl:
+      - '50.000'
+      X-Ttl-Rule:
+      - '0'
+      X-Varnish:
+      - 10.76.2.237
+      - '2257439745'
+      Content-Length:
+      - '2027'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"$type":"Tfl.Api.Presentation.Entities.Prediction, Tfl.Api.Presentation.Entities","id":"-2093286148","operationType":1,"vehicleId":"215","naptanId":"940GZZLUSVS","stationName":"Seven
+        Sisters Underground Station","lineId":"victoria","lineName":"Victoria","platformName":"Northbound
+        - Platform 3","direction":"outbound","destinationNaptanId":"940GZZLUWWL","destinationName":"Walthamstow
+        Central Underground Station","timestamp":"2016-01-19T15:47:09.036Z","timeToStation":359,"currentLocation":"Between
+        Kings Cross St. Pancras and Highbury & Isl","towards":"Walthamstow Central","expectedArrival":"2016-01-19T15:53:08.036Z","timeToLive":"2016-01-19T15:53:08.036Z","modeName":"tube"},{"$type":"Tfl.Api.Presentation.Entities.Prediction,
+        Tfl.Api.Presentation.Entities","id":"-1691213171","operationType":1,"vehicleId":"232","naptanId":"940GZZLUSVS","stationName":"Seven
+        Sisters Underground Station","lineId":"victoria","lineName":"Victoria","platformName":"Northbound
+        - Platform 3","direction":"outbound","destinationNaptanId":"940GZZLUWWL","destinationName":"Walthamstow
+        Central Underground Station","timestamp":"2016-01-19T15:47:09.005Z","timeToStation":89,"currentLocation":"Between
+        Finsbury Park and Seven Sisters","towards":"Walthamstow Central","expectedArrival":"2016-01-19T15:48:38.005Z","timeToLive":"2016-01-19T15:48:38.005Z","modeName":"tube"},{"$type":"Tfl.Api.Presentation.Entities.Prediction,
+        Tfl.Api.Presentation.Entities","id":"-796707333","operationType":1,"vehicleId":"250","naptanId":"940GZZLUSVS","stationName":"Seven
+        Sisters Underground Station","lineId":"victoria","lineName":"Victoria","platformName":"Northbound
+        - Platform 3","direction":"outbound","destinationNaptanId":"940GZZLUWWL","destinationName":"Walthamstow
+        Central Underground Station","timestamp":"2016-01-19T15:47:09.036Z","timeToStation":299,"currentLocation":"Between
+        Highbury & Islington and Finsbury Park","towards":"Walthamstow Central","expectedArrival":"2016-01-19T15:52:08.036Z","timeToLive":"2016-01-19T15:52:08.036Z","modeName":"tube"}]'
+    http_version: 
+  recorded_at: Fri, 01 Jan 2016 15:44:00 GMT
+recorded_with: VCR 3.0.0

--- a/lib/sir_handel.rb
+++ b/lib/sir_handel.rb
@@ -265,6 +265,7 @@ module SirHandel
 
         wants.html do
           @title = 'Arriving trains'
+          @next_trains = NextTrains.new(db_signal(@station), @direction.to_sym).results
           erb :arrivals, layout: :default
         end
 

--- a/lib/sir_handel.rb
+++ b/lib/sir_handel.rb
@@ -14,6 +14,7 @@ require_relative 'sir_handel/helpers'
 require_relative 'sir_handel/racks'
 require_relative 'sir_handel/tasks'
 require_relative 'sir_handel/trends'
+require_relative 'sir_handel/next_trains'
 
 Dotenv.load
 

--- a/lib/sir_handel.rb
+++ b/lib/sir_handel.rb
@@ -256,7 +256,9 @@ module SirHandel
       if params[:to]
         @to = Time.parse(params[:to])
       else
-        to = DateTime.parse('2015-09-23T08:30:00').to_s
+        hour = Time.now.hour
+        minute = Time.now.min
+        to = DateTime.parse("2015-09-23T#{hour}:#{minute}:00").to_s
         redirect to "/stations/arriving/#{params[:direction]}/#{params[:station]}/#{to}"
       end
 

--- a/lib/sir_handel/next_trains.rb
+++ b/lib/sir_handel/next_trains.rb
@@ -1,0 +1,40 @@
+module SirHandel
+  class NextTrains
+
+    def initialize(station, direction)
+      @station = naptan(station)
+      @direction = direction(direction)
+    end
+
+    def url
+      "https://api.tfl.gov.uk/line/victoria/arrivals?stopPointId=#{@station}&direction=#{@direction}"
+    end
+
+    def json
+      r = Curl::Easy.http_get(url)
+      JSON.parse(r.body)
+    end
+
+    def results
+      json.map { |result|
+        (result['timeToStation'].to_f / 60).round
+      }.sort
+    end
+
+    def naptan(station)
+      stations[station]['naptan']
+    end
+
+    def direction(dir)
+      {
+        northbound: 'inbound',
+        southbound: 'outbound',
+      }[dir]
+    end
+
+    def stations
+      YAML.load_file File.join('config', 'stations.yml')
+    end
+
+  end
+end

--- a/public/javascripts/arrivals.js
+++ b/public/javascripts/arrivals.js
@@ -1,12 +1,11 @@
-function populateTrain(data, index) {
-  var train = '#train-' + index
+function populateTrain(data, train) {
   $.each(['f', 'r'], function(i, side) {
     $.each(['a', 'b', 'c', 'd'], function(j, letter) {
       var car = 'car-' + letter;
       var value = data[1][car.toUpperCase().replace('-', '_')];
 
-      $(train + ' #' + car + '-' + side + ' .num').text(percentage(value))
-      setHeight(train + ' #' + car + '-' + side + ' .level', value)
+      $(train).find('#' + car + '-' + side + ' .num').text(percentage(value))
+      setHeight($(train).find('#' + car + '-' + side + ' .level'), value)
     })
   })
 }

--- a/public/style.css
+++ b/public/style.css
@@ -119,8 +119,13 @@ form {
   border-radius: 20px 5px 5px 5px;
 }
 
+.arrival-time {
+  margin: 10px 0;
+  padding: 0;
+}
+
 .train {
-  margin: 40px auto;
+  margin: 30px auto;
 }
 
 .wheel {

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -170,10 +170,12 @@ module SirHandel
       get '/signals/passesnger-load-car-a,passesnger-load-car-b/2015-08-29T00:00:00+00:00/2015-08-30T00:00:00+00:00?layout=simple'
     end
 
-    it 'sets a default datetime' do
+    it 'sets a default datetime at the same local time', :vcr do
+      Timecop.freeze('2016-01-01T15:44:00Z')
       get 'stations/arriving/southbound/seven-sisters'
       follow_redirect!
-      expect(last_request.url).to eq 'http://example.org/stations/arriving/southbound/seven-sisters/2015-09-23T08:30:00+00:00'
+      expect(last_request.url).to eq 'http://example.org/stations/arriving/southbound/seven-sisters/2015-09-23T15:44:00+00:00'
+      Timecop.return
     end
 
     it 'allows the datetime to be set', :vcr do

--- a/spec/javascripts/arrivals_spec.js
+++ b/spec/javascripts/arrivals_spec.js
@@ -38,7 +38,7 @@ describe('arrivals', function() {
         }
       ]
 
-      populateTrain(data, 0)
+      populateTrain(data, $('#train-0')[0])
 
       expect($('#car-a-r .num').text()).toEqual('77%');
       expect($('#car-b-r .num').text()).toEqual('67%');

--- a/spec/next_train_spec.rb
+++ b/spec/next_train_spec.rb
@@ -1,0 +1,47 @@
+module SirHandel
+  describe NextTrains do
+
+    it 'gets a correct naptan ID' do
+      next_trains = described_class.new('warren_street', :southbound)
+      expect(next_trains.instance_variable_get('@station')).to eq('940GZZLUWRR')
+    end
+
+    it 'gets a correct directions' do
+      next_trains = described_class.new('warren_street', :northbound)
+      expect(next_trains.instance_variable_get('@direction')).to eq('inbound')
+    end
+
+    it 'builds a correct url' do
+      next_trains = described_class.new('warren_street', :southbound)
+      expect(next_trains.url).to eq('https://api.tfl.gov.uk/line/victoria/arrivals?stopPointId=940GZZLUWRR&direction=outbound')
+    end
+
+    it 'gets the next trains' do
+      json = [
+        {
+          'timeToStation' => 417
+        },
+        {
+          'timeToStation' => 177
+        },
+        {
+          'timeToStation' => 537
+        },
+        {
+          'timeToStation' => 297
+        },
+      ]
+
+      stub_request(:get, "https://api.tfl.gov.uk/line/victoria/arrivals?stopPointId=940GZZLUWRR&direction=outbound").
+            to_return(:body => json.to_json)
+
+      result = described_class.new('warren_street', :southbound).results
+
+      expect(result[0]).to eq(3)
+      expect(result[1]).to eq(5)
+      expect(result[2]).to eq(7)
+      expect(result[3]).to eq(9)
+    end
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,8 @@ end
 require 'rack/test'
 require 'nokogiri'
 require 'timecop'
+require 'webmock/rspec'
+
 require_relative 'support/vcr_setup'
 
 require File.expand_path '../../lib/sir_handel.rb', __FILE__

--- a/views/arrivals.erb
+++ b/views/arrivals.erb
@@ -5,6 +5,7 @@
 <h2>Next <%= params[:direction] %> trains at <%= I18n.t "stations.#{db_signal params[:station]}" %></h2>
 
 <% 4.times do |i| %>
+  <h3>In <%= @next_trains[i] %> minutes</h3>
   <%= erb :'includes/train', locals: { num: i } %>
 <% end %>
 

--- a/views/arrivals.erb
+++ b/views/arrivals.erb
@@ -4,8 +4,8 @@
 
 <h2>Next <%= params[:direction] %> trains at <%= I18n.t "stations.#{db_signal params[:station]}" %></h2>
 
-<% 4.times do |i| %>
-  <h3 class="arrival-time">In <%= @next_trains[i] %> minutes</h3>
+<% @next_trains.each_with_index do |minutes, i| %>
+  <h3 class="arrival-time">In <%= minutes %> minutes</h3>
   <%= erb :'includes/train', locals: { num: i } %>
 <% end %>
 
@@ -14,7 +14,7 @@
 
 <script>
 $.getJSON(document.URL, function(data) {
-  $.each([0,1,2,3], function(i) {
+  $.each($('.train'), function(i, train) {
     if (data[i]) {
       populateTrain(data[i], i)
     }

--- a/views/arrivals.erb
+++ b/views/arrivals.erb
@@ -16,7 +16,7 @@
 $.getJSON(document.URL, function(data) {
   $.each($('.train'), function(i, train) {
     if (data[i]) {
-      populateTrain(data[i], i)
+      populateTrain(data[i], train)
     }
   })
 })

--- a/views/arrivals.erb
+++ b/views/arrivals.erb
@@ -5,7 +5,7 @@
 <h2>Next <%= params[:direction] %> trains at <%= I18n.t "stations.#{db_signal params[:station]}" %></h2>
 
 <% 4.times do |i| %>
-  <h3>In <%= @next_trains[i] %> minutes</h3>
+  <h3 class="arrival-time">In <%= @next_trains[i] %> minutes</h3>
   <%= erb :'includes/train', locals: { num: i } %>
 <% end %>
 


### PR DESCRIPTION
This uses the TfL API to show when the next trains are expected (as of the local time). It also redirects to the current time on the default date (currently the 23rd Sept) to give a more realistic picture of what the network would look like at the moment.
