### PR TITLE
Make front more obvious

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -65,7 +65,7 @@ form {
 }
 
 .carriage-wrapper {
-  width: 10%;
+  width: 11%;
   float: left;
   margin: 0 0.5% 0 0;
 }
@@ -116,7 +116,7 @@ form {
 
 .front, .rear {
   border: 2px solid #000;
-  width: 5%;
+  width: 4%;
   height: 50px;
   float: left;
   position: relative;

--- a/views/includes/train.erb
+++ b/views/includes/train.erb
@@ -1,7 +1,4 @@
 <div class='row train' id ='train-<%= num %>'>
-  <div class='rear'>
-    <div class='window'></div>
-  </div>
 
   <% ('a'..'d').each do |l| %>
   <div class='carriage-wrapper' id='car-<%= l %>-r'>


### PR DESCRIPTION
Remove the rear carriage, so it's clearer which way the train's facing:

![download 3](https://cloud.githubusercontent.com/assets/109774/13348635/7dfd21c4-dc6c-11e5-9163-9413d3ca9027.png)
